### PR TITLE
Update setup.py to fix typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ import pyaws
 
 
 requires = [
-    'awscli'
+    'awscli',
     'boto3',
     'botocore',
     'libtools',


### PR DESCRIPTION
```
...
https://pypi.org:443 "GET /simple/awscliboto3/ HTTP/1.1" 404 13
Status code 404 not in (200, 203, 300, 301, 308)
Could not fetch URL https://pypi.org/simple/awscliboto3/: 404 Client Error: Not Found for url: https://pypi.org/simple/awscliboto3/ - skipping
...
```

this is what it shows when I run `pip -vvv install metal`, I think it's the missing comma that cause this issue, correct me if I'm wrong. thanks.